### PR TITLE
fix: Set Groq API key correctly. Remove "All" from MODEL_PROVIDERS

### DIFF
--- a/app/[locale]/(dashboard)/settings/page.tsx
+++ b/app/[locale]/(dashboard)/settings/page.tsx
@@ -13,6 +13,7 @@ import { useAuthModal } from "@/app/lib/providers/AuthContextProvider"
 import { ProfileSettings } from "@/app/components/settings/ProfileSettings"
 import { Button, Tab, Tabs } from "@nextui-org/react"
 import { Icon } from "@iconify-icon/react"
+import { TablesUpdate } from "@/supabase/types"
 
 export default function SettingsPage() {
   const searchParams = useSearchParams()
@@ -65,7 +66,7 @@ export default function SettingsPage() {
   const [azureOpenai45VisionID, setAzureOpenai45VisionID] = useState(
     profile?.azure_openai_45_vision_id || ""
   )
-  const [azureEmbeddingsID, setAzureEmbeddingsID] = useState(
+  const [azureOpenaiEmbeddingsID, setAzureOpenaiEmbeddingsID] = useState(
     profile?.azure_openai_embeddings_id || ""
   )
   const [anthropicAPIKey, setAnthropicAPIKey] = useState(
@@ -93,6 +94,7 @@ export default function SettingsPage() {
       return
     }
 
+    // TODO: Check if `profileImageURL` or `profileImagePath` is used correctly
     let profileImageUrl = profile.image_url
     let profileImagePath = ""
 
@@ -102,29 +104,29 @@ export default function SettingsPage() {
       profileImagePath = path
     }
 
-    const updatedProfile = await updateProfile(profile.id, {
+    const updateProfilePayload: TablesUpdate<"profiles"> = {
       ...profile,
+      has_onboarded: true,
       display_name: displayName,
       username,
-      profile_context: profileInstructions,
-      image_url: profileImageUrl,
-      image_path: profileImagePath,
       openai_api_key: openaiAPIKey,
       openai_organization_id: openaiOrgID,
       anthropic_api_key: anthropicAPIKey,
       google_gemini_api_key: googleGeminiAPIKey,
       mistral_api_key: mistralAPIKey,
+      groq_api_key: groqAPIKey,
       perplexity_api_key: perplexityAPIKey,
+      openrouter_api_key: openrouterAPIKey,
       use_azure_openai: useAzureOpenai,
       azure_openai_api_key: azureOpenaiAPIKey,
       azure_openai_endpoint: azureOpenaiEndpoint,
       azure_openai_35_turbo_id: azureOpenai35TurboID,
       azure_openai_45_turbo_id: azureOpenai45TurboID,
       azure_openai_45_vision_id: azureOpenai45VisionID,
-      azure_openai_embeddings_id: azureEmbeddingsID,
-      openrouter_api_key: openrouterAPIKey
-    })
+      azure_openai_embeddings_id: azureOpenaiEmbeddingsID
+    }
 
+    const updatedProfile = await updateProfile(profile.id, updateProfilePayload)
     setProfile(updatedProfile)
 
     toast.success("Profile updated!")
@@ -204,7 +206,7 @@ export default function SettingsPage() {
     setAzureOpenai35TurboID(profile?.azure_openai_35_turbo_id || "")
     setAzureOpenai45TurboID(profile?.azure_openai_45_turbo_id || "")
     setAzureOpenai45VisionID(profile?.azure_openai_45_vision_id || "")
-    setAzureEmbeddingsID(profile?.azure_openai_embeddings_id || "")
+    setAzureOpenaiEmbeddingsID(profile?.azure_openai_embeddings_id || "")
     setAnthropicAPIKey(profile?.anthropic_api_key || "")
     setGoogleGeminiAPIKey(profile?.google_gemini_api_key || "")
     setMistralAPIKey(profile?.mistral_api_key || "")
@@ -278,7 +280,7 @@ export default function SettingsPage() {
               azureOpenai35TurboID={azureOpenai35TurboID}
               azureOpenai45TurboID={azureOpenai45TurboID}
               azureOpenai45VisionID={azureOpenai45VisionID}
-              azureOpenaiEmbeddingsID={azureEmbeddingsID}
+              azureOpenaiEmbeddingsID={azureOpenaiEmbeddingsID}
               anthropicAPIKey={anthropicAPIKey}
               googleGeminiAPIKey={googleGeminiAPIKey}
               mistralAPIKey={mistralAPIKey}
@@ -293,7 +295,7 @@ export default function SettingsPage() {
               onAzureOpenai35TurboIDChange={setAzureOpenai35TurboID}
               onAzureOpenai45TurboIDChange={setAzureOpenai45TurboID}
               onAzureOpenai45VisionIDChange={setAzureOpenai45VisionID}
-              onAzureOpenaiEmbeddingsIDChange={setAzureEmbeddingsID}
+              onAzureOpenaiEmbeddingsIDChange={setAzureOpenaiEmbeddingsID}
               onAnthropicAPIKeyChange={setAnthropicAPIKey}
               onGoogleGeminiAPIKeyChange={setGoogleGeminiAPIKey}
               onMistralAPIKeyChange={setMistralAPIKey}

--- a/app/components/models/ModelFilterDropdown.tsx
+++ b/app/components/models/ModelFilterDropdown.tsx
@@ -1,6 +1,23 @@
 import React from "react"
-import { MODEL_PROVIDERS } from "@/app/components/models/ModelSelect"
 import { Select, SelectItem } from "@nextui-org/react"
+
+export const MODEL_PROVIDERS = {
+  Local: "Local",
+  Hosted: "Hosted",
+  OpenAI: "OpenAI",
+  Google: "Google",
+  Groq: "Groq",
+  Mistral: "Mistral",
+  Perplexity: "Perplexity",
+  Anthropic: "Anthropic",
+  OpenRouter: "OpenRouter",
+  Ollama: "Ollama"
+} as const
+
+export const MODEL_FILTERS = {
+  ...MODEL_PROVIDERS,
+  All: "All"
+} as const
 
 export function ModelFilterDropdown({
   modelFilter,
@@ -17,14 +34,14 @@ export function ModelFilterDropdown({
     <Select
       variant="faded"
       isDisabled={isDisabled}
-      defaultSelectedKeys={[MODEL_PROVIDERS[0]]}
+      defaultSelectedKeys={[MODEL_FILTERS.All]}
       value={modelFilter}
       onChange={e => {
-        setModelFilter(e.target.value ?? MODEL_PROVIDERS[0])
+        setModelFilter(e.target.value ?? MODEL_FILTERS.All)
       }}
       className={`w-36 ${className}`}
     >
-      {MODEL_PROVIDERS.map(filter => (
+      {Object.keys(MODEL_FILTERS).map(filter => (
         <SelectItem value={filter} key={filter}>
           {filter}
         </SelectItem>

--- a/app/components/models/ModelFilterDropdown.tsx
+++ b/app/components/models/ModelFilterDropdown.tsx
@@ -9,8 +9,6 @@ export const MODEL_PROVIDERS = {
   Perplexity: "Perplexity",
   Anthropic: "Anthropic",
   OpenRouter: "OpenRouter",
-  Local: "Local",
-  Hosted: "Hosted",
   Ollama: "Ollama"
 }
 

--- a/app/components/models/ModelFilterDropdown.tsx
+++ b/app/components/models/ModelFilterDropdown.tsx
@@ -2,8 +2,6 @@ import React from "react"
 import { Select, SelectItem } from "@nextui-org/react"
 
 export const MODEL_PROVIDERS = {
-  Local: "Local",
-  Hosted: "Hosted",
   OpenAI: "OpenAI",
   Google: "Google",
   Groq: "Groq",
@@ -12,12 +10,14 @@ export const MODEL_PROVIDERS = {
   Anthropic: "Anthropic",
   OpenRouter: "OpenRouter",
   Ollama: "Ollama"
-} as const
+}
 
 export const MODEL_FILTERS = {
-  ...MODEL_PROVIDERS,
-  All: "All"
-} as const
+  All: "All",
+  Local: "Local",
+  Hosted: "Hosted",
+  ...MODEL_PROVIDERS
+}
 
 export function ModelFilterDropdown({
   modelFilter,

--- a/app/components/models/ModelSelect.tsx
+++ b/app/components/models/ModelSelect.tsx
@@ -2,7 +2,11 @@ import { MetadachiContext } from "@/app/lib/context"
 import { LLM, LLMID, ModelProvider } from "@/app/lib/types"
 import React, { FC, useContext, useState } from "react"
 import { ModelIcon } from "./ModelIcon"
-import { ModelFilterDropdown } from "@/app/components/models/ModelFilterDropdown"
+import {
+  MODEL_FILTERS,
+  MODEL_PROVIDERS,
+  ModelFilterDropdown
+} from "@/app/components/models/ModelFilterDropdown"
 import {
   Autocomplete,
   AutocompleteItem,
@@ -10,19 +14,6 @@ import {
   Tooltip
 } from "@nextui-org/react"
 import { SHOW_MODEL_COST } from "@/app/lib/config"
-
-const MODEL_FILTERS = {
-  All: "All",
-  Local: "Local",
-  Hosted: "Hosted",
-  OpenAI: "OpenAI",
-  Google: "Google",
-  Mistral: "Mistral",
-  Perplexity: "Perplexity",
-  Anthropic: "Anthropic",
-  OpenRouter: "OpenRouter",
-  Ollama: "Ollama"
-} as const
 
 interface ModelSelectProps {
   isDisabled?: boolean
@@ -33,9 +24,6 @@ interface ModelSelectProps {
   label?: string
   labelPlacement?: "outside" | "inside"
 }
-
-type ModelFilter = (typeof MODEL_FILTERS)[keyof typeof MODEL_FILTERS]
-export const MODEL_PROVIDERS = Object.keys(MODEL_FILTERS) as ModelFilter[]
 
 export const ModelSelect: FC<ModelSelectProps> = ({
   isDisabled,
@@ -53,7 +41,7 @@ export const ModelSelect: FC<ModelSelectProps> = ({
     availableOpenRouterModels
   } = useContext(MetadachiContext)
 
-  const [modelFilter, setModelFilter] = useState<string>(MODEL_PROVIDERS[0])
+  const [modelFilter, setModelFilter] = useState<string>(MODEL_FILTERS.All)
   // const [filteredModels, setFilteredModels] = useState<LLM[]>([])
   // const [isLocked, setIsLocked] = useState<boolean>(true)
   // const [lockedModels, setLockedModels] = useState<LLMID[]>([])
@@ -165,7 +153,7 @@ export const ModelSelect: FC<ModelSelectProps> = ({
         )
       }
     >
-      {MODEL_PROVIDERS.map(provider => (
+      {Object.keys(MODEL_PROVIDERS).map(provider => (
         <AutocompleteSection key={provider} title={provider}>
           {filteredModels
             .filter(model => model.provider === provider.toLowerCase())

--- a/app/components/settings/SettingsModal.tsx
+++ b/app/components/settings/SettingsModal.tsx
@@ -19,6 +19,7 @@ import {
   Tabs
 } from "@nextui-org/react"
 import { Icon } from "@iconify-icon/react"
+import { TablesUpdate } from "@/supabase/types"
 
 // TODO: Fix profile data sometimes not loading, leading to an empty form
 export default function SettingsModal({
@@ -74,7 +75,7 @@ export default function SettingsModal({
   const [azureOpenai45VisionID, setAzureOpenai45VisionID] = useState(
     profile?.azure_openai_45_vision_id || ""
   )
-  const [azureEmbeddingsID, setAzureEmbeddingsID] = useState(
+  const [azureOpenaiEmbeddingsID, setAzureOpenaiEmbeddingsID] = useState(
     profile?.azure_openai_embeddings_id || ""
   )
   const [anthropicAPIKey, setAnthropicAPIKey] = useState(
@@ -111,29 +112,29 @@ export default function SettingsModal({
       profileImagePath = path
     }
 
-    const updatedProfile = await updateProfile(profile.id, {
+    const updateProfilePayload: TablesUpdate<"profiles"> = {
       ...profile,
+      has_onboarded: true,
       display_name: displayName,
       username,
-      profile_context: profileInstructions,
-      image_url: profileImageUrl,
-      image_path: profileImagePath,
       openai_api_key: openaiAPIKey,
       openai_organization_id: openaiOrgID,
       anthropic_api_key: anthropicAPIKey,
       google_gemini_api_key: googleGeminiAPIKey,
       mistral_api_key: mistralAPIKey,
+      groq_api_key: groqAPIKey,
       perplexity_api_key: perplexityAPIKey,
+      openrouter_api_key: openrouterAPIKey,
       use_azure_openai: useAzureOpenai,
       azure_openai_api_key: azureOpenaiAPIKey,
       azure_openai_endpoint: azureOpenaiEndpoint,
       azure_openai_35_turbo_id: azureOpenai35TurboID,
       azure_openai_45_turbo_id: azureOpenai45TurboID,
       azure_openai_45_vision_id: azureOpenai45VisionID,
-      azure_openai_embeddings_id: azureEmbeddingsID,
-      openrouter_api_key: openrouterAPIKey
-    })
+      azure_openai_embeddings_id: azureOpenaiEmbeddingsID
+    }
 
+    const updatedProfile = await updateProfile(profile.id, updateProfilePayload)
     setProfile(updatedProfile)
 
     toast.success("Profile updated!")
@@ -213,7 +214,7 @@ export default function SettingsModal({
     setAzureOpenai35TurboID(profile?.azure_openai_35_turbo_id || "")
     setAzureOpenai45TurboID(profile?.azure_openai_45_turbo_id || "")
     setAzureOpenai45VisionID(profile?.azure_openai_45_vision_id || "")
-    setAzureEmbeddingsID(profile?.azure_openai_embeddings_id || "")
+    setAzureOpenaiEmbeddingsID(profile?.azure_openai_embeddings_id || "")
     setAnthropicAPIKey(profile?.anthropic_api_key || "")
     setGoogleGeminiAPIKey(profile?.google_gemini_api_key || "")
     setMistralAPIKey(profile?.mistral_api_key || "")
@@ -281,7 +282,7 @@ export default function SettingsModal({
                 azureOpenai35TurboID={azureOpenai35TurboID}
                 azureOpenai45TurboID={azureOpenai45TurboID}
                 azureOpenai45VisionID={azureOpenai45VisionID}
-                azureOpenaiEmbeddingsID={azureEmbeddingsID}
+                azureOpenaiEmbeddingsID={azureOpenaiEmbeddingsID}
                 anthropicAPIKey={anthropicAPIKey}
                 googleGeminiAPIKey={googleGeminiAPIKey}
                 mistralAPIKey={mistralAPIKey}
@@ -296,7 +297,7 @@ export default function SettingsModal({
                 onAzureOpenai35TurboIDChange={setAzureOpenai35TurboID}
                 onAzureOpenai45TurboIDChange={setAzureOpenai45TurboID}
                 onAzureOpenai45VisionIDChange={setAzureOpenai45VisionID}
-                onAzureOpenaiEmbeddingsIDChange={setAzureEmbeddingsID}
+                onAzureOpenaiEmbeddingsIDChange={setAzureOpenaiEmbeddingsID}
                 onAnthropicAPIKeyChange={setAnthropicAPIKey}
                 onGoogleGeminiAPIKeyChange={setGoogleGeminiAPIKey}
                 onMistralAPIKeyChange={setMistralAPIKey}


### PR DESCRIPTION
- Resolve issue where Groq API key would not be set
- Refactor logic for `MODEL_PROVIDERS` and `MODEL_FILTERS`
- `ModelSelect` will no longer display "All", "Hosted", and "Local" sections (still available as filter)